### PR TITLE
Upgrade to latest version of NTP, and pull version from pillar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.x.0
+
+* Specify specific version of ntp package to be installed (which is pulled from
+* a defaulted pillar key of ntp:version)
+
 ## Version 1.0.1
 
 * Disable monitor commands from all hosts to prevent our use in an

--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -1,12 +1,12 @@
+{% from "ntp/map.jinja" import ntp with context %}
+
 ntp:
-  pkg:
-    - installed
-  service:
-    - running
+  pkg.installed:
+    - version: {{ ntp.version }}
+  service.running:
     - watch:
       - file: /etc/ntp.conf
-  file:
-    - managed
+  file.managed:
     - name: /etc/ntp.conf
     - source: salt://ntp/templates/ntp.conf
     - mode: 644

--- a/ntp/map.jinja
+++ b/ntp/map.jinja
@@ -1,6 +1,10 @@
 {% set ntp = salt['grains.filter_by']({
-    'Debian': {
-        'servers': ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'],
+    'Ubuntu-12.04': {
+        'version': '1:4.2.6.p3+dfsg-1ubuntu3.2',
     },
-    'default': 'Debian',
-}, merge=salt['pillar.get']('npt',{})) %}
+    'Ubuntu-14.04': {
+        'version': '1:4.2.6.p5+dfsg-3ubuntu2.14.04.1',
+    },
+}, grain='osfinger', merge=salt['pillar.get']('ntp', merge=True, default={
+    'servers': ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'],
+}, )) %}


### PR DESCRIPTION
Salt recommends not using pkg.latest as it will cause an apt-get update every run, so for now we’ll just have to keep on top of upgrades.