### PR TITLE
Add the "tinker panic 0" directive to the configuration/template.

### DIFF
--- a/ntp/templates/ntp.conf
+++ b/ntp/templates/ntp.conf
@@ -4,6 +4,8 @@
 
 driftfile /var/lib/ntp/ntp.drift
 
+# Makes time sync more aggressively in a VM.
+tinker panic 0
 
 # Enable this if you want statistics to be logged.
 #statsdir /var/log/ntpstats/


### PR DESCRIPTION
See the following for details:

  http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1006427

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>