### PR TITLE
Default ntp version to latest

### DIFF
--- a/ntp/map.jinja
+++ b/ntp/map.jinja
@@ -1,11 +1,11 @@
 {% set ntp = salt['grains.filter_by']({
     'Ubuntu-12.04': {
-        'version': '1:4.2.6.p3+dfsg-1ubuntu3.3',
+        'version': '',
         'servers': ['0.pool.ntp.org', '1.pool.ntp.org',
                     '2.pool.ntp.org', '3.pool.ntp.org'],
     },
     'Ubuntu-14.04': {
-        'version': '1:4.2.6.p5+dfsg-3ubuntu2.14.04.3',
+        'version': '',
         'servers': ['0.pool.ntp.org', '1.pool.ntp.org',
                     '2.pool.ntp.org', '3.pool.ntp.org'],
     },


### PR DESCRIPTION
This change will mean that we will always get the latest available
ntp version unless we explicitly request a specific version in our
pillar data.