### PR TITLE
fix issue #9 Make ntp-formula check for collectd

### DIFF
--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -1,5 +1,10 @@
 {% from "ntp/map.jinja" import ntp with context %}
-
+collectd_restart:
+  cmd.wait:
+    - name: service collectd restart
+    - watch:
+      - pkg: ntp
+      
 ntp:
   pkg.installed:
     - version: {{ ntp.version }}


### PR DESCRIPTION
If ntp is installed when collectd is already running, the ntp plugin will not notice the change and will remain broken. We need to make collectd restart to react to the ntpd starting