### PR TITLE
Fix collectd restart on ntp installation

### DIFF
--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -1,10 +1,12 @@
 {% from "ntp/map.jinja" import ntp with context %}
+{% if salt['status.pid']('collectd') %}
 collectd_restart:
   cmd.wait:
     - name: service collectd restart
     - watch:
       - pkg: ntp
-      
+{% endif %}
+
 ntp:
   pkg.installed:
     - version: {{ ntp.version }}


### PR DESCRIPTION
We attempt to restart collectd whether or not its installed. This change
makes it so we check for the pid of a running collectd process before
attemption a restart.